### PR TITLE
feat: 使用非 root 用户运行 Docker 容器以提高安全性

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,6 +107,15 @@ COPY --from=publish /app/publish .
 COPY docker/docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 
+# ============================================
+# 创建非 root 用户以提高安全性
+# ============================================
+RUN groupadd -r appuser && useradd -r -g appuser -u 1000 appuser \
+    && chown -R appuser:appuser /app
+
+# 切换到非 root 用户
+USER appuser
+
 # 暴露端口
 EXPOSE 5000
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -80,13 +80,14 @@ echo "  5) 查看日志"
 echo "  6) 查看状态"
 echo "  7) 进入容器"
 echo "  8) 完全重置 (删除数据)"
+echo "  9) 清理旧镜像并重新构建"
 echo ""
-read -p "请输入选项 [1-8]: " choice
+read -p "请输入选项 [1-9]: " choice
 
 case $choice in
     1)
         echo -e "${GREEN}正在构建并启动...${NC}"
-        docker compose build
+        docker compose build --no-cache
         docker compose up -d
         echo ""
         echo -e "${GREEN}✓ 部署完成！${NC}"
@@ -134,6 +135,16 @@ case $choice in
         else
             echo "操作已取消"
         fi
+        ;;
+    9)
+        echo -e "${GREEN}正在清理旧镜像并重新构建...${NC}"
+        docker compose down
+        docker rmi webcodecli:latest 2>/dev/null || echo "旧镜像不存在，跳过"
+        docker compose build --no-cache
+        docker compose up -d
+        echo ""
+        echo -e "${GREEN}✓ 清理并重新部署完成！${NC}"
+        echo "访问地址: http://localhost:${APP_PORT:-5000}"
         ;;
     *)
         echo -e "${RED}无效选项${NC}"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -15,7 +15,7 @@ echo "============================================"
 # ============================================
 echo "Generating Codex configuration..."
 
-CODEX_CONFIG_DIR="/root/.codex"
+CODEX_CONFIG_DIR="$HOME/.codex"
 CODEX_CONFIG_FILE="${CODEX_CONFIG_DIR}/config.toml"
 
 # 确保配置目录存在


### PR DESCRIPTION
- Dockerfile: 添加 appuser (UID 1000) 用户和组，容器以非 root 用户运行
- docker-entrypoint.sh: 配置目录从 /root/.codex 改为 $HOME/.codex
- deploy.sh: 所有构建选项使用 --no-cache，新增清理旧镜像选项 9

修复问题:
解决 --dangerously-skip-permissions 在 root 权限下的安全限制错误