### PR TITLE
fix: 将容器用户 UID 从 1000 改为 1001 避免与基础镜像冲突

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ RUN chmod +x /docker-entrypoint.sh
 # ============================================
 # 创建非 root 用户以提高安全性
 # ============================================
-RUN groupadd -r appuser && useradd -r -g appuser -u 1000 appuser \
+RUN groupadd -r appuser && useradd -r -g appuser -u 1001 appuser \
     && chown -R appuser:appuser /app
 
 # 切换到非 root 用户


### PR DESCRIPTION
错误: UID 1000 is not unique
原因: .NET base image (aspnet:10.0) 已存在 UID 1000 用户