### PR TITLE
fix: 添加 -m 参数创建 appuser 的 home 目录

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ RUN chmod +x /docker-entrypoint.sh
 # ============================================
 # 创建非 root 用户以提高安全性
 # ============================================
-RUN groupadd -r appuser && useradd -r -g appuser -u 1001 appuser \
+RUN groupadd -r appuser && useradd -r -g appuser -u 1001 -m appuser \
     && chown -R appuser:appuser /app
 
 # 切换到非 root 用户


### PR DESCRIPTION
错误: mkdir: cannot create directory '/home/appuser': Permission denied
解决: useradd -m 会自动创建 /home/appuser 目录