### PR TITLE
fix: 移除 entrypoint 中的 chmod 命令避免权限错误

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -115,11 +115,6 @@ mkdir -p /app/data
 mkdir -p /app/workspaces
 mkdir -p /app/logs
 
-# 设置权限
-chmod -R 755 /app/data
-chmod -R 755 /app/workspaces
-chmod -R 755 /app/logs
-
 echo ""
 
 # ============================================


### PR DESCRIPTION
错误: chmod: changing permissions of '/app/workspaces': Operation not permitted
原因: Docker volumes 之前以 root 创建，appuser 无法修改
解决: 移除 chmod，volumes 权限由 Docker 管理